### PR TITLE
Fix Docker API version compatibility for Docker 29.0+

### DIFF
--- a/dev/script/init-agent.sh
+++ b/dev/script/init-agent.sh
@@ -15,7 +15,7 @@ else
     docker run -d \
       --publish 8888:8080 \
       --name swarmpitagent \
-      --env DOCKER_API_VERSION=1.30 \
+      --env DOCKER_API_VERSION=1.44 \
       --env EVENT_ENDPOINT=http://192.168.65.2:3449/events \
       --env HEALTH_CHECK_ENDPOINT=http://192.168.65.2:3449/version \
       --volume /var/run/docker.sock:/var/run/docker.sock \

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -8,7 +8,7 @@ Default is `/var/run/docker.sock`.
 
 ## `SWARMPIT_DOCKER_API`
 Docker API version used by docker client.
-Default is `1.30`.
+Default is `1.44`. Docker Engine 29.0+ requires at least API `1.44`.
 
 ## `SWARMPIT_DOCKER_HTTP_TIMEOUT`
 Docker client http timeout in ms.

--- a/docker-compose.arm.yml
+++ b/docker-compose.arm.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - SWARMPIT_DB=http://db:5984
       - SWARMPIT_INFLUXDB=http://influxdb:8086
+      - SWARMPIT_DOCKER_API=1.44
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - SWARMPIT_DB=http://db:5984
       - SWARMPIT_INFLUXDB=http://influxdb:8086
+      - SWARMPIT_DOCKER_API=1.44
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:


### PR DESCRIPTION
## Summary

Fixes #714

Docker Engine 29.0+ requires minimum API version `1.44`, but several files still referenced the legacy `1.30` default, causing Swarmpit to crash on startup:

```
ERROR: Event channel error: Error response from daemon: client version 1.35 is too old.
Minimum supported API version is 1.44, please upgrade your client to a newer version
panic: Event collector is broken. Shutdown!!!
```

## Changes

| File | Before | After |
|------|--------|-------|
| `doc/configuration.md` | Default documented as `1.30` | Updated to `1.44` with Docker 29+ note |
| `dev/script/init-agent.sh` | `DOCKER_API_VERSION=1.30` | `1.44` |
| `docker-compose.yml` | No explicit `SWARMPIT_DOCKER_API` on app | Added `SWARMPIT_DOCKER_API=1.44` |
| `docker-compose.arm.yml` | No explicit `SWARMPIT_DOCKER_API` on app | Added `SWARMPIT_DOCKER_API=1.44` |

## Context

The code default in `config.clj` and the agent entries in both compose files were already updated to `1.44`, but the documentation and dev script were stale. The app service also lacked an explicit env override — relying solely on the code default means users deploying with older compose files or overriding images could still hit the issue.

Adding explicit `SWARMPIT_DOCKER_API=1.44` to the compose files ensures out-of-the-box compatibility regardless of the image version used.

Note: Swarmpit already auto-negotiates the actual API version at startup via `setup.clj`, but the initial default must be `>= 1.44` for the bootstrap `/version` call to succeed on Docker 29+ daemons.